### PR TITLE
Feature/#10

### DIFF
--- a/GWNU Club/Assets.xcassets/TagColor.colorset/Contents.json
+++ b/GWNU Club/Assets.xcassets/TagColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD9",
+          "green" : "0xD9",
+          "red" : "0xD9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD9",
+          "green" : "0xD9",
+          "red" : "0xD9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GWNU Club/Common/Extensions/Color+Extension.swift
+++ b/GWNU Club/Common/Extensions/Color+Extension.swift
@@ -9,4 +9,5 @@ import SwiftUI
 
 extension Color {
     static let primaryColor = Color("PrimaryColor")
+    static let tagColor = Color("TagColor")
 }

--- a/GWNU Club/Common/Extensions/Font+Extension.swift
+++ b/GWNU Club/Common/Extensions/Font+Extension.swift
@@ -1,10 +1,3 @@
-//
-//  Font+Extension.swift
-//  GWNU Club
-//
-//  Created by 박세민 on 10/27/24.
-//
-
 import SwiftUI
 
 extension Font {

--- a/GWNU Club/Common/Extensions/Keyboard+Extension.swift
+++ b/GWNU Club/Common/Extensions/Keyboard+Extension.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension View {
+    func hideKeyboard() {
+        let resign = #selector(UIResponder.resignFirstResponder)
+        UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
+    }
+}

--- a/GWNU Club/Views/ClubListView.swift
+++ b/GWNU Club/Views/ClubListView.swift
@@ -1,10 +1,3 @@
-//
-//  Untitled.swift
-//  GWNU Club
-//
-//  Created by 박세민 on 10/25/24.
-//
-
 import SwiftUI
 
 enum Campus: String, CaseIterable, Identifiable {
@@ -22,7 +15,34 @@ enum ClubType: String, CaseIterable, Identifiable {
     var id: Self { self }
 }
 
+struct Club {
+    var id: Int
+    var name: String
+    var logo: Image?
+    var thumbnail: Image?
+    var hashtags: [String]
+}
+
 struct ClubListView: View {
+    
+    private var gridItems: [GridItem] = [
+        GridItem(spacing: 16), GridItem()
+    ]
+    private var colors: [Color] = [.red, .blue, .green, .yellow]
+    private var clubs: [Club] = [
+        Club(id: 1, name: "동아리1", hashtags: ["사진", "친목"]),
+        Club(id: 2, name: "동아리2", hashtags: ["사진", "친목"]),
+        Club(id: 3, name: "동아리3", hashtags: ["사진", "친목"]),
+        Club(id: 4, name: "동아리4", hashtags: ["사진", "친목"]),
+        Club(id: 5, name: "동아리5", hashtags: ["사진", "친목"]),
+        Club(id: 6, name: "동아리6", hashtags: ["사진", "친목"]),
+        Club(id: 7, name: "동아리7", hashtags: ["사진", "친목"]),
+        Club(id: 8, name: "동아리8", hashtags: ["사진", "친목"]),
+        Club(id: 9, name: "동아리9", hashtags: ["사진", "친목"]),
+        Club(id: 10, name: "동아리10", hashtags: ["사진", "친목"]),
+        Club(id: 11, name: "동아리12", hashtags: ["사진", "친목"]),
+        Club(id: 12, name: "동아리12", hashtags: ["사진", "친목"])
+    ]
     
     @State private var searchClub: String = ""
     @State private var selectedCampus: Campus = Campus.gangneung
@@ -31,11 +51,13 @@ struct ClubListView: View {
     var body: some View {
         VStack {
             
+            // 상단 네모 박스
             ZStack(alignment: .top) {
                 
+                // 배경색
                 Rectangle()
                     .fill(Color.primaryColor)
-                    .frame(height: 285)
+                    .frame(height: 280)
                 
                 VStack {
                     
@@ -49,7 +71,7 @@ struct ClubListView: View {
                     }
                      
                     VStack {
-                        
+                        // 캠퍼스 선택 Picker
                         Picker("Campus", selection: $selectedCampus) {
                             ForEach(Campus.allCases) {
                                 Text($0.rawValue)
@@ -59,9 +81,8 @@ struct ClubListView: View {
                         .background(RoundedRectangle(cornerRadius: 7)
                             .foregroundStyle(Color(white: 1, opacity: 0.2)))
                         .frame(width: 250)
-                        .padding(.bottom, 10)
                         
-                        
+                        // 동아리 분야 선택 Picker
                         Picker("Type", selection: $selectedType) {
                             ForEach(ClubType.allCases) {
                                 Text($0.rawValue)
@@ -70,22 +91,29 @@ struct ClubListView: View {
                         .pickerStyle(.segmented)
                         .background(RoundedRectangle(cornerRadius: 7)
                             .foregroundStyle(Color(white: 1, opacity: 0.2)))
-                        
                     }
-                    .padding(.vertical, 10)
-                    
+                    .padding(.top, 10)
                 }
                 .padding()
                 .safeAreaPadding(.top, 45)
                 
             }
             
+            // 동아리 목록
             ScrollView {
-                Text("동아리 목록 여기에")
+                LazyVGrid(columns: gridItems) {
+                    ForEach(clubs, id: \.id) { club in
+                        ClubItem(club: club)
+                    }
+                }
+                .padding(.horizontal)
             }
             
         }
         .ignoresSafeArea(edges: .top)
+        .onTapGesture {
+            hideKeyboard()
+        }
     }
 
 }
@@ -93,6 +121,7 @@ struct ClubListView: View {
 struct SearchBar: View {
     
     @Binding var searchClub: String
+    @FocusState var isFocused: Bool
     
     var body: some View {
         ZStack {
@@ -102,6 +131,25 @@ struct SearchBar: View {
             
             HStack {
                 TextField("동아리명으로 검색", text: $searchClub)
+                    .focused($isFocused)
+                    .keyboardType(.namePhonePad)
+                    .autocorrectionDisabled()
+                    .onSubmit {
+                        isFocused = false
+                        search()
+                    }
+                    .submitLabel(.search)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            
+                            Button(action: {
+                                isFocused = false
+                            }, label: {
+                                Text("완료")
+                            })
+                        }
+                    }
                     .padding(.trailing, 3)
                 
                 Image(systemName: "magnifyingglass")
@@ -113,12 +161,65 @@ struct SearchBar: View {
                         .frame(width: 40, height: 40)
                         .foregroundStyle(Color.primaryColor))
                     .onTapGesture {
-                        print("Enter : \(searchClub)")
-                        searchClub.removeAll()
+                        isFocused = false
+                        search()
                     }
             }
             .padding(.horizontal, 16)
         }
+        
+    }
+    
+    func search() {
+        searchClub.removeAll()
+        print("SEARCH: \(searchClub)")
+    }
+}
+
+struct ClubItem: View {
+    var club: Club
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Image(systemName: "matter.logo")
+                .resizable()
+                .frame(height: 120)
+                .scaledToFill()
+                .border(.gray, width: 1)
+            
+            VStack(alignment: .leading, spacing: 5) {
+                HStack {
+                    Image(systemName: "apple.logo")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 32, height: 32)
+                    
+                    Text(club.name)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
+                
+                HStack {
+                    Text("  #\(club.hashtags[0])  ")
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .padding(8)
+                        .background(RoundedRectangle(cornerRadius: 20).fill(Color.tagColor))
+                    
+                    Spacer()
+                    
+                    Text("  #\(club.hashtags[1])  ")
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .padding(8)
+                        .background(RoundedRectangle(cornerRadius: 20).fill(Color.tagColor))
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.bottom, 10)
+        }
+        .frame(width: 180)
+        .border(.gray, width: 2)
     }
 }
 

--- a/GWNU Club/Views/ContentView.swift
+++ b/GWNU Club/Views/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  GWNU Club
-//
-//  Created by 박세민 on 10/10/24.
-//
-
 import SwiftUI
 
 struct ContentView: View {

--- a/GWNU Club/Views/SplashView.swift
+++ b/GWNU Club/Views/SplashView.swift
@@ -1,10 +1,3 @@
-//
-//  SplashView.swift
-//  GWNU Club
-//
-//  Created by 박세민 on 10/14/24.
-//
-
 import SwiftUI
 
 struct SplashView: View {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #10   

## 📝 작업 내용  
- 동아리의 정보를 나타내기 위한 구조체 Club 정의
- 결과 확인을 위해 임시로 12개의 동아리 데이터를 만들어 사용
- ScrollView, LazyVGrid를 사용하여 동아리 목록 구현
- 동아리별 [썸네일, 로고, 동아리명, 해시태그 2개]가 표시

- SearchBar에서 입력을 다 하고 빈 곳을 터치하면 키보드가 숨겨지도록 설정(extension 추가하였음)
- SearchBar의 키보드 타입을 정하였고, 자동 추천 문구가 뜨지 않도록 하였으며, 엔터 버튼을 '검색' 버튼으로 변경함

## 📷 결과 사진  
| 동아리 목록 | SearchBar |
|-----------|------------|
|![1](https://github.com/user-attachments/assets/0cb5141c-a5af-45d4-92c7-af7be6884556)|![2](https://github.com/user-attachments/assets/193e3f50-ad66-4ba2-8f7f-466d52aac140)|
